### PR TITLE
Update and rename build.yml to main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   Palladio-Analyzer-Dependability-ML:
-    uses: PalladioSimulator/Palladio-Build-ActionsPipeline/.github/workflows/build.yml@v3.3
+    uses: PalladioSimulator/Palladio-Build-ActionsPipeline/.github/workflows/build.yml@v3.4
     with:
       use-display-output: true
       no-caching: true


### PR DESCRIPTION
This update is part of the new [dynamic build pipeline](https://github.com/PalladioSimulator/Palladio-Build-Nightly/tree/autogenerate) for nightly builds.

As discussed with @Nicolas-Boltz @larissaschmid 
- Updated to https://github.com/PalladioSimulator/Palladio-Build-ActionsPipeline/releases/tag/v3.4
- Rename build file to opt-out of the nightly build